### PR TITLE
Dodaj testy integracyjne dla StrategyController i SimulationController

### DIFF
--- a/src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java
+++ b/src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java
@@ -1,0 +1,136 @@
+package piotrholda.portfoliomanager.simulation.in.http;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class SimulationControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void shouldSimulateDualEquityMomentumAndReturnCsv() {
+        importQuotations("SIM_BENCH", "100", "101", "102", "103");
+        importQuotations("SIM_RISK_FREE", "100", "100.5", "101", "101.5");
+        importQuotations("SIM_RISK_ON", "100", "110", "120", "130");
+        importQuotations("SIM_RISK_OFF", "100", "99", "98", "97");
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/v1/simulation/dualEquityMomentum",
+                dualEquityMomentumRequest("SIM_"),
+                String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(MediaType.valueOf("text/csv"), response.getHeaders().getContentType());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().startsWith("Date,"));
+        assertTrue(response.getBody().contains("SIM_BENCH"));
+        assertTrue(response.getBody().contains("SIM_RISK_FREE"));
+        assertTrue(response.getBody().contains("SIM_RISK_ON"));
+        assertTrue(response.getBody().contains("SIM_RISK_OFF"));
+        List<Map<String, String>> csvRows = parseCsv(response.getBody());
+        assertEquals(2, csvRows.size());
+        assertCsvRow(csvRows.get(0), "2024-03-31", "0.00", "0.00", "0.00", "0.00", "0.00", "SIM_RISK_ON");
+        assertCsvRow(csvRows.get(1), "2024-04-30", "0.98", "0.50", "8.33", "-1.02", "8.33", "");
+    }
+
+    private List<Map<String, String>> parseCsv(String csv) {
+        String[] lines = csv.split("\n");
+        String[] headers = lines[0].split(",", -1);
+        List<Map<String, String>> rows = new java.util.ArrayList<>();
+        for (int i = 1; i < lines.length; i++) {
+            String[] values = lines[i].split(",", -1);
+            Map<String, String> row = new java.util.HashMap<>();
+            for (int j = 0; j < headers.length; j++) {
+                row.put(headers[j], values[j]);
+            }
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    private void assertCsvRow(Map<String, String> row, String date, String benchmark, String riskFree, String riskOn,
+                              String riskOff, String results, String transaction) {
+        assertEquals(date, row.get("Date"));
+        assertEquals(benchmark, row.get("SIM_BENCH"));
+        assertEquals(riskFree, row.get("SIM_RISK_FREE"));
+        assertEquals(riskOn, row.get("SIM_RISK_ON"));
+        assertEquals(riskOff, row.get("SIM_RISK_OFF"));
+        assertEquals(results, row.get("Results"));
+        assertEquals(transaction, row.get("Transaction"));
+    }
+
+    private void importQuotations(String code, String first, String second, String third, String fourth) {
+        byte[] csvBytes = ("Data,Otwarcie,Najwyzszy,Najnizszy,Zamkniecie,Wolumen\n"
+                + "2024-01-31," + first + "," + first + "," + first + "," + first + ",1000\n"
+                + "2024-02-29," + second + "," + second + "," + second + "," + second + ",1000\n"
+                + "2024-03-31," + third + "," + third + "," + third + "," + third + ",1000\n"
+                + "2024-04-30," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n")
+                .getBytes(StandardCharsets.UTF_8);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("code", code);
+        body.add("exchangeCode", "WSE");
+        body.add("currencyCode", "PLN");
+        body.add("file", new ByteArrayResource(csvBytes) {
+            @Override
+            public String getFilename() {
+                return code.toLowerCase() + ".csv";
+            }
+        });
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        ResponseEntity<Void> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/v1/quotation/import/csv",
+                new HttpEntity<>(body, headers),
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
+    private Map<String, Object> dualEquityMomentumRequest(String prefix) {
+        return Map.of(
+                "currencyCode", "PLN",
+                "benchmark", ticker(prefix + "BENCH"),
+                "lookBackPeriod", 1,
+                "riskOffLookBackPeriod", 1,
+                "riskOn", List.of(ticker(prefix + "RISK_ON")),
+                "riskFree", ticker(prefix + "RISK_FREE"),
+                "riskOff", List.of(ticker(prefix + "RISK_OFF")),
+                "skipMonths", 0
+        );
+    }
+
+    private Map<String, String> ticker(String code) {
+        return Map.of("code", code, "exchangeCode", "WSE", "currencyCode", "PLN");
+    }
+}

--- a/src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java
+++ b/src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java
@@ -1,5 +1,8 @@
 package piotrholda.portfoliomanager.simulation.in.http;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,9 +15,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -27,18 +35,35 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ActiveProfiles("test")
 class SimulationControllerIntegrationTest {
 
+    private static HttpServer stockApiStub;
+    private static String stockApiBasePath;
+
     @LocalServerPort
     private int port;
 
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @AfterAll
+    static void stopStub() {
+        if (stockApiStub != null) {
+            stockApiStub.stop(0);
+        }
+    }
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        startStub();
+        registry.add("stock-api.base-path", () -> stockApiBasePath);
+    }
+
     @Test
     void shouldSimulateDualEquityMomentumAndReturnCsv() {
-        importQuotations("SIM_BENCH", "100", "101", "102", "103", "104");
-        importQuotations("SIM_RISK_FREE", "100", "100.5", "101", "101.5", "102");
-        importQuotations("SIM_RISK_ON", "100", "110", "120", "130", "140");
-        importQuotations("SIM_RISK_OFF", "100", "99", "98", "97", "96");
+        importQuotations("SIM_BENCH", "100", "101", "102", "103", "104", "105", "106");
+        importQuotations("SIM_RISK_FREE", "100", "100.5", "101", "101.5", "102", "102.5", "103");
+        importQuotations("SIM_RISK_ON", "100", "110", "120", "130", "100", "90", "80");
+        importQuotations("SIM_RISK_OFF", "100", "99", "98", "97", "110", "120", "130");
+        importCorporateActions("SIM_RISK_OFF");
 
         ResponseEntity<String> response = restTemplate.postForEntity(
                 "http://localhost:" + port + "/v1/simulation/dualEquityMomentum",
@@ -55,10 +80,12 @@ class SimulationControllerIntegrationTest {
         assertTrue(response.getBody().contains("SIM_RISK_ON"));
         assertTrue(response.getBody().contains("SIM_RISK_OFF"));
         List<Map<String, String>> csvRows = parseCsv(response.getBody());
-        assertEquals(3, csvRows.size());
+        assertEquals(5, csvRows.size());
         assertCsvRow(csvRows.get(0), "2024-02-29", "0.00", "0.00", "0.00", "0.00", "0.00", "SIM_RISK_ON");
         assertCsvRow(csvRows.get(1), "2024-03-31", "0.98", "0.50", "8.33", "-1.02", "8.33", "");
-        assertCsvRow(csvRows.get(2), "2024-04-30", "1.96", "0.99", "16.67", "-2.04", "16.67", "");
+        assertCsvRow(csvRows.get(2), "2024-04-30", "1.96", "0.99", "-16.67", "12.24", "-16.67", "");
+        assertCsvRow(csvRows.get(3), "2024-05-31", "2.94", "1.49", "-25.00", "22.45", "-25.00", "SIM_RISK_OFF");
+        assertCsvRow(csvRows.get(4), "2024-06-30", "3.92", "1.98", "-33.33", "165.31", "62.50", "");
     }
 
     private List<Map<String, String>> parseCsv(String csv) {
@@ -87,19 +114,22 @@ class SimulationControllerIntegrationTest {
         assertEquals(transaction, row.get("Transaction"));
     }
 
-    private void importQuotations(String code, String first, String second, String third, String fourth, String fifth) {
+    private void importQuotations(String code, String first, String second, String third, String fourth, String fifth,
+                                  String sixth, String seventh) {
         byte[] csvBytes = ("Data,Otwarcie,Najwyzszy,Najnizszy,Zamkniecie,Wolumen\n"
                 + "2023-12-31," + first + "," + first + "," + first + "," + first + ",1000\n"
                 + "2024-01-31," + second + "," + second + "," + second + "," + second + ",1000\n"
                 + "2024-02-29," + third + "," + third + "," + third + "," + third + ",1000\n"
                 + "2024-03-31," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n"
-                + "2024-04-30," + fifth + "," + fifth + "," + fifth + "," + fifth + ",1000\n")
+                + "2024-04-30," + fifth + "," + fifth + "," + fifth + "," + fifth + ",1000\n"
+                + "2024-05-31," + sixth + "," + sixth + "," + sixth + "," + sixth + ",1000\n"
+                + "2024-06-30," + seventh + "," + seventh + "," + seventh + "," + seventh + ",1000\n")
                 .getBytes(StandardCharsets.UTF_8);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add("code", code);
-        body.add("exchangeCode", "WSE");
-        body.add("currencyCode", "PLN");
+        body.add("exchangeCode", "NYSE");
+        body.add("currencyCode", "USD");
         body.add("file", new ByteArrayResource(csvBytes) {
             @Override
             public String getFilename() {
@@ -119,9 +149,19 @@ class SimulationControllerIntegrationTest {
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
     }
 
+    private void importCorporateActions(String code) {
+        ResponseEntity<Void> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/v1/corporateaction/import",
+                Map.of("code", code),
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
     private Map<String, Object> dualEquityMomentumRequest(String prefix) {
         return Map.of(
-                "currencyCode", "PLN",
+                "currencyCode", "USD",
                 "benchmark", ticker(prefix + "BENCH"),
                 "lookBackPeriod", 1,
                 "riskOffLookBackPeriod", 1,
@@ -133,6 +173,39 @@ class SimulationControllerIntegrationTest {
     }
 
     private Map<String, String> ticker(String code) {
-        return Map.of("code", code, "exchangeCode", "WSE", "currencyCode", "PLN");
+        return Map.of("code", code, "exchangeCode", "NYSE", "currencyCode", "USD");
+    }
+
+    private static void handleStockDataRequest(HttpExchange exchange) throws IOException {
+        String ticker = exchange.getRequestURI().getQuery().replace("ticker=", "");
+        String response = "{"
+                + "\"ticker\":\"" + ticker + "\","
+                + "\"dividends\":[],"
+                + "\"splits\":[{"
+                + "\"Date\":\"2024-06-15\","
+                + "\"Split Ratio\":\"2.0\""
+                + "}]"
+                + "}";
+        byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
+
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, responseBytes.length);
+        try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(responseBytes);
+        }
+    }
+
+    private static void startStub() {
+        if (stockApiStub != null) {
+            return;
+        }
+        try {
+            stockApiStub = HttpServer.create(new InetSocketAddress(0), 0);
+            stockApiStub.createContext("/api/stock-data", SimulationControllerIntegrationTest::handleStockDataRequest);
+            stockApiStub.start();
+            stockApiBasePath = "http://localhost:" + stockApiStub.getAddress().getPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to start stock API stub server", e);
+        }
     }
 }

--- a/src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java
+++ b/src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java
@@ -35,10 +35,10 @@ class SimulationControllerIntegrationTest {
 
     @Test
     void shouldSimulateDualEquityMomentumAndReturnCsv() {
-        importQuotations("SIM_BENCH", "100", "101", "102", "103");
-        importQuotations("SIM_RISK_FREE", "100", "100.5", "101", "101.5");
-        importQuotations("SIM_RISK_ON", "100", "110", "120", "130");
-        importQuotations("SIM_RISK_OFF", "100", "99", "98", "97");
+        importQuotations("SIM_BENCH", "100", "101", "102", "103", "104");
+        importQuotations("SIM_RISK_FREE", "100", "100.5", "101", "101.5", "102");
+        importQuotations("SIM_RISK_ON", "100", "110", "120", "130", "140");
+        importQuotations("SIM_RISK_OFF", "100", "99", "98", "97", "96");
 
         ResponseEntity<String> response = restTemplate.postForEntity(
                 "http://localhost:" + port + "/v1/simulation/dualEquityMomentum",
@@ -55,9 +55,10 @@ class SimulationControllerIntegrationTest {
         assertTrue(response.getBody().contains("SIM_RISK_ON"));
         assertTrue(response.getBody().contains("SIM_RISK_OFF"));
         List<Map<String, String>> csvRows = parseCsv(response.getBody());
-        assertEquals(2, csvRows.size());
-        assertCsvRow(csvRows.get(0), "2024-03-31", "0.00", "0.00", "0.00", "0.00", "0.00", "SIM_RISK_ON");
-        assertCsvRow(csvRows.get(1), "2024-04-30", "0.98", "0.50", "8.33", "-1.02", "8.33", "");
+        assertEquals(3, csvRows.size());
+        assertCsvRow(csvRows.get(0), "2024-02-29", "0.00", "0.00", "0.00", "0.00", "0.00", "SIM_RISK_ON");
+        assertCsvRow(csvRows.get(1), "2024-03-31", "0.98", "0.50", "8.33", "-1.02", "8.33", "");
+        assertCsvRow(csvRows.get(2), "2024-04-30", "1.96", "0.99", "16.67", "-2.04", "16.67", "");
     }
 
     private List<Map<String, String>> parseCsv(String csv) {
@@ -86,12 +87,13 @@ class SimulationControllerIntegrationTest {
         assertEquals(transaction, row.get("Transaction"));
     }
 
-    private void importQuotations(String code, String first, String second, String third, String fourth) {
+    private void importQuotations(String code, String first, String second, String third, String fourth, String fifth) {
         byte[] csvBytes = ("Data,Otwarcie,Najwyzszy,Najnizszy,Zamkniecie,Wolumen\n"
-                + "2024-01-31," + first + "," + first + "," + first + "," + first + ",1000\n"
-                + "2024-02-29," + second + "," + second + "," + second + "," + second + ",1000\n"
-                + "2024-03-31," + third + "," + third + "," + third + "," + third + ",1000\n"
-                + "2024-04-30," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n")
+                + "2023-12-31," + first + "," + first + "," + first + "," + first + ",1000\n"
+                + "2024-01-31," + second + "," + second + "," + second + "," + second + ",1000\n"
+                + "2024-02-29," + third + "," + third + "," + third + "," + third + ",1000\n"
+                + "2024-03-31," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n"
+                + "2024-04-30," + fifth + "," + fifth + "," + fifth + "," + fifth + ",1000\n")
                 .getBytes(StandardCharsets.UTF_8);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();

--- a/src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java
+++ b/src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java
@@ -35,10 +35,10 @@ class StrategyControllerIntegrationTest {
 
     @Test
     void shouldExecuteDualEquityMomentumAndReturnCsv() {
-        importQuotations("STR_BENCH", "100", "101", "102", "103");
-        importQuotations("STR_RISK_FREE", "100", "100.5", "101", "101.5");
-        importQuotations("STR_RISK_ON", "100", "110", "120", "130");
-        importQuotations("STR_RISK_OFF", "100", "99", "98", "97");
+        importQuotations("STR_BENCH", "100", "101", "102", "103", "104");
+        importQuotations("STR_RISK_FREE", "100", "100.5", "101", "101.5", "102");
+        importQuotations("STR_RISK_ON", "100", "110", "120", "130", "140");
+        importQuotations("STR_RISK_OFF", "100", "99", "98", "97", "96");
 
         ResponseEntity<String> response = restTemplate.postForEntity(
                 "http://localhost:" + port + "/v1/strategy/dualEquityMomentum",
@@ -55,11 +55,12 @@ class StrategyControllerIntegrationTest {
         assertTrue(response.getBody().contains("STR_RISK_ON"));
         assertTrue(response.getBody().contains("STR_RISK_OFF"));
         List<Map<String, String>> csvRows = parseCsv(response.getBody());
-        assertEquals(4, csvRows.size());
-        assertCsvRow(csvRows.get(0), "2024-01-31", "100.00", "100.50", "110.00", "99.00", "");
-        assertCsvRow(csvRows.get(1), "2024-02-29", "101.00", "101.00", "120.00", "98.00", "");
-        assertCsvRow(csvRows.get(2), "2024-03-31", "102.00", "101.50", "130.00", "97.00", "STR_RISK_ON");
-        assertCsvRow(csvRows.get(3), "2024-04-30", "103.00", "102.00", "130.00", "96.00", "");
+        assertEquals(5, csvRows.size());
+        assertCsvRow(csvRows.get(0), "2023-12-31", "100.00", "100.00", "100.00", "100.00", "");
+        assertCsvRow(csvRows.get(1), "2024-01-31", "101.00", "100.50", "110.00", "99.00", "");
+        assertCsvRow(csvRows.get(2), "2024-02-29", "102.00", "101.00", "120.00", "98.00", "STR_RISK_ON");
+        assertCsvRow(csvRows.get(3), "2024-03-31", "103.00", "101.50", "130.00", "97.00", "");
+        assertCsvRow(csvRows.get(4), "2024-04-30", "104.00", "102.00", "140.00", "96.00", "");
     }
 
     private List<Map<String, String>> parseCsv(String csv) {
@@ -87,12 +88,13 @@ class StrategyControllerIntegrationTest {
         assertEquals(transaction, row.get("Transaction"));
     }
 
-    private void importQuotations(String code, String first, String second, String third, String fourth) {
+    private void importQuotations(String code, String first, String second, String third, String fourth, String fifth) {
         byte[] csvBytes = ("Data,Otwarcie,Najwyzszy,Najnizszy,Zamkniecie,Wolumen\n"
-                + "2024-01-31," + first + "," + first + "," + first + "," + first + ",1000\n"
-                + "2024-02-29," + second + "," + second + "," + second + "," + second + ",1000\n"
-                + "2024-03-31," + third + "," + third + "," + third + "," + third + ",1000\n"
-                + "2024-04-30," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n")
+                + "2023-12-31," + first + "," + first + "," + first + "," + first + ",1000\n"
+                + "2024-01-31," + second + "," + second + "," + second + "," + second + ",1000\n"
+                + "2024-02-29," + third + "," + third + "," + third + "," + third + ",1000\n"
+                + "2024-03-31," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n"
+                + "2024-04-30," + fifth + "," + fifth + "," + fifth + "," + fifth + ",1000\n")
                 .getBytes(StandardCharsets.UTF_8);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();

--- a/src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java
+++ b/src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java
@@ -1,5 +1,8 @@
 package piotrholda.portfoliomanager.strategy.http;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,9 +15,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -27,18 +35,35 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ActiveProfiles("test")
 class StrategyControllerIntegrationTest {
 
+    private static HttpServer stockApiStub;
+    private static String stockApiBasePath;
+
     @LocalServerPort
     private int port;
 
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @AfterAll
+    static void stopStub() {
+        if (stockApiStub != null) {
+            stockApiStub.stop(0);
+        }
+    }
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        startStub();
+        registry.add("stock-api.base-path", () -> stockApiBasePath);
+    }
+
     @Test
     void shouldExecuteDualEquityMomentumAndReturnCsv() {
-        importQuotations("STR_BENCH", "100", "101", "102", "103", "104");
-        importQuotations("STR_RISK_FREE", "100", "100.5", "101", "101.5", "102");
-        importQuotations("STR_RISK_ON", "100", "110", "120", "130", "140");
-        importQuotations("STR_RISK_OFF", "100", "99", "98", "97", "96");
+        importQuotations("STR_BENCH", "100", "101", "102", "103", "104", "105", "106");
+        importQuotations("STR_RISK_FREE", "100", "100.5", "101", "101.5", "102", "102.5", "103");
+        importQuotations("STR_RISK_ON", "100", "110", "120", "130", "100", "90", "80");
+        importQuotations("STR_RISK_OFF", "100", "99", "98", "97", "110", "120", "130");
+        importCorporateActions("STR_RISK_OFF");
 
         ResponseEntity<String> response = restTemplate.postForEntity(
                 "http://localhost:" + port + "/v1/strategy/dualEquityMomentum",
@@ -55,12 +80,14 @@ class StrategyControllerIntegrationTest {
         assertTrue(response.getBody().contains("STR_RISK_ON"));
         assertTrue(response.getBody().contains("STR_RISK_OFF"));
         List<Map<String, String>> csvRows = parseCsv(response.getBody());
-        assertEquals(5, csvRows.size());
-        assertCsvRow(csvRows.get(0), "2023-12-31", "100.00", "100.00", "100.00", "100.00", "");
-        assertCsvRow(csvRows.get(1), "2024-01-31", "101.00", "100.50", "110.00", "99.00", "");
-        assertCsvRow(csvRows.get(2), "2024-02-29", "102.00", "101.00", "120.00", "98.00", "STR_RISK_ON");
-        assertCsvRow(csvRows.get(3), "2024-03-31", "103.00", "101.50", "130.00", "97.00", "");
-        assertCsvRow(csvRows.get(4), "2024-04-30", "104.00", "102.00", "140.00", "96.00", "");
+        assertEquals(7, csvRows.size());
+        assertCsvRow(csvRows.get(0), "2023-12-31", "100.00", "100.00", "100.00", "50.00", "");
+        assertCsvRow(csvRows.get(1), "2024-01-31", "101.00", "100.50", "110.00", "49.50", "");
+        assertCsvRow(csvRows.get(2), "2024-02-29", "102.00", "101.00", "120.00", "49.00", "STR_RISK_ON");
+        assertCsvRow(csvRows.get(3), "2024-03-31", "103.00", "101.50", "130.00", "48.50", "");
+        assertCsvRow(csvRows.get(4), "2024-04-30", "104.00", "102.00", "100.00", "55.00", "");
+        assertCsvRow(csvRows.get(5), "2024-05-31", "105.00", "102.50", "90.00", "60.00", "STR_RISK_OFF");
+        assertCsvRow(csvRows.get(6), "2024-06-30", "106.00", "103.00", "80.00", "130.00", "");
     }
 
     private List<Map<String, String>> parseCsv(String csv) {
@@ -88,19 +115,22 @@ class StrategyControllerIntegrationTest {
         assertEquals(transaction, row.get("Transaction"));
     }
 
-    private void importQuotations(String code, String first, String second, String third, String fourth, String fifth) {
+    private void importQuotations(String code, String first, String second, String third, String fourth, String fifth,
+                                  String sixth, String seventh) {
         byte[] csvBytes = ("Data,Otwarcie,Najwyzszy,Najnizszy,Zamkniecie,Wolumen\n"
                 + "2023-12-31," + first + "," + first + "," + first + "," + first + ",1000\n"
                 + "2024-01-31," + second + "," + second + "," + second + "," + second + ",1000\n"
                 + "2024-02-29," + third + "," + third + "," + third + "," + third + ",1000\n"
                 + "2024-03-31," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n"
-                + "2024-04-30," + fifth + "," + fifth + "," + fifth + "," + fifth + ",1000\n")
+                + "2024-04-30," + fifth + "," + fifth + "," + fifth + "," + fifth + ",1000\n"
+                + "2024-05-31," + sixth + "," + sixth + "," + sixth + "," + sixth + ",1000\n"
+                + "2024-06-30," + seventh + "," + seventh + "," + seventh + "," + seventh + ",1000\n")
                 .getBytes(StandardCharsets.UTF_8);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add("code", code);
-        body.add("exchangeCode", "WSE");
-        body.add("currencyCode", "PLN");
+        body.add("exchangeCode", "NYSE");
+        body.add("currencyCode", "USD");
         body.add("file", new ByteArrayResource(csvBytes) {
             @Override
             public String getFilename() {
@@ -120,9 +150,19 @@ class StrategyControllerIntegrationTest {
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
     }
 
+    private void importCorporateActions(String code) {
+        ResponseEntity<Void> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/v1/corporateaction/import",
+                Map.of("code", code),
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
     private Map<String, Object> dualEquityMomentumRequest(String prefix) {
         return Map.of(
-                "currencyCode", "PLN",
+                "currencyCode", "USD",
                 "benchmark", ticker(prefix + "BENCH"),
                 "lookBackPeriod", 1,
                 "riskOffLookBackPeriod", 1,
@@ -134,6 +174,39 @@ class StrategyControllerIntegrationTest {
     }
 
     private Map<String, String> ticker(String code) {
-        return Map.of("code", code, "exchangeCode", "WSE", "currencyCode", "PLN");
+        return Map.of("code", code, "exchangeCode", "NYSE", "currencyCode", "USD");
+    }
+
+    private static void handleStockDataRequest(HttpExchange exchange) throws IOException {
+        String ticker = exchange.getRequestURI().getQuery().replace("ticker=", "");
+        String response = "{"
+                + "\"ticker\":\"" + ticker + "\","
+                + "\"dividends\":[],"
+                + "\"splits\":[{"
+                + "\"Date\":\"2024-06-15\","
+                + "\"Split Ratio\":\"2.0\""
+                + "}]"
+                + "}";
+        byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
+
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, responseBytes.length);
+        try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(responseBytes);
+        }
+    }
+
+    private static void startStub() {
+        if (stockApiStub != null) {
+            return;
+        }
+        try {
+            stockApiStub = HttpServer.create(new InetSocketAddress(0), 0);
+            stockApiStub.createContext("/api/stock-data", StrategyControllerIntegrationTest::handleStockDataRequest);
+            stockApiStub.start();
+            stockApiBasePath = "http://localhost:" + stockApiStub.getAddress().getPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to start stock API stub server", e);
+        }
     }
 }

--- a/src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java
+++ b/src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java
@@ -1,0 +1,137 @@
+package piotrholda.portfoliomanager.strategy.http;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class StrategyControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void shouldExecuteDualEquityMomentumAndReturnCsv() {
+        importQuotations("STR_BENCH", "100", "101", "102", "103");
+        importQuotations("STR_RISK_FREE", "100", "100.5", "101", "101.5");
+        importQuotations("STR_RISK_ON", "100", "110", "120", "130");
+        importQuotations("STR_RISK_OFF", "100", "99", "98", "97");
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/v1/strategy/dualEquityMomentum",
+                dualEquityMomentumRequest("STR_"),
+                String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(MediaType.valueOf("text/csv"), response.getHeaders().getContentType());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().startsWith("Date,"));
+        assertTrue(response.getBody().contains("STR_BENCH"));
+        assertTrue(response.getBody().contains("STR_RISK_FREE"));
+        assertTrue(response.getBody().contains("STR_RISK_ON"));
+        assertTrue(response.getBody().contains("STR_RISK_OFF"));
+        List<Map<String, String>> csvRows = parseCsv(response.getBody());
+        assertEquals(4, csvRows.size());
+        assertCsvRow(csvRows.get(0), "2024-01-31", "100.00", "100.50", "110.00", "99.00", "");
+        assertCsvRow(csvRows.get(1), "2024-02-29", "101.00", "101.00", "120.00", "98.00", "");
+        assertCsvRow(csvRows.get(2), "2024-03-31", "102.00", "101.50", "130.00", "97.00", "STR_RISK_ON");
+        assertCsvRow(csvRows.get(3), "2024-04-30", "103.00", "102.00", "130.00", "96.00", "");
+    }
+
+    private List<Map<String, String>> parseCsv(String csv) {
+        String[] lines = csv.split("\n");
+        String[] headers = lines[0].split(",", -1);
+        List<Map<String, String>> rows = new java.util.ArrayList<>();
+        for (int i = 1; i < lines.length; i++) {
+            String[] values = lines[i].split(",", -1);
+            Map<String, String> row = new java.util.HashMap<>();
+            for (int j = 0; j < headers.length; j++) {
+                row.put(headers[j], values[j]);
+            }
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    private void assertCsvRow(Map<String, String> row, String date, String benchmark, String riskFree, String riskOn,
+                              String riskOff, String transaction) {
+        assertEquals(date, row.get("Date"));
+        assertEquals(benchmark, row.get("STR_BENCH"));
+        assertEquals(riskFree, row.get("STR_RISK_FREE"));
+        assertEquals(riskOn, row.get("STR_RISK_ON"));
+        assertEquals(riskOff, row.get("STR_RISK_OFF"));
+        assertEquals(transaction, row.get("Transaction"));
+    }
+
+    private void importQuotations(String code, String first, String second, String third, String fourth) {
+        byte[] csvBytes = ("Data,Otwarcie,Najwyzszy,Najnizszy,Zamkniecie,Wolumen\n"
+                + "2024-01-31," + first + "," + first + "," + first + "," + first + ",1000\n"
+                + "2024-02-29," + second + "," + second + "," + second + "," + second + ",1000\n"
+                + "2024-03-31," + third + "," + third + "," + third + "," + third + ",1000\n"
+                + "2024-04-30," + fourth + "," + fourth + "," + fourth + "," + fourth + ",1000\n")
+                .getBytes(StandardCharsets.UTF_8);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("code", code);
+        body.add("exchangeCode", "WSE");
+        body.add("currencyCode", "PLN");
+        body.add("file", new ByteArrayResource(csvBytes) {
+            @Override
+            public String getFilename() {
+                return code.toLowerCase() + ".csv";
+            }
+        });
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        ResponseEntity<Void> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/v1/quotation/import/csv",
+                new HttpEntity<>(body, headers),
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
+    private Map<String, Object> dualEquityMomentumRequest(String prefix) {
+        return Map.of(
+                "currencyCode", "PLN",
+                "benchmark", ticker(prefix + "BENCH"),
+                "lookBackPeriod", 1,
+                "riskOffLookBackPeriod", 1,
+                "riskOn", List.of(ticker(prefix + "RISK_ON")),
+                "riskFree", ticker(prefix + "RISK_FREE"),
+                "riskOff", List.of(ticker(prefix + "RISK_OFF")),
+                "skipMonths", 0
+        );
+    }
+
+    private Map<String, String> ticker(String code) {
+        return Map.of("code", code, "exchangeCode", "WSE", "currencyCode", "PLN");
+    }
+}


### PR DESCRIPTION
### Motivation
- Dodać integracyjne testy sprawdzające zwracane CSV z endpointów strategii i symulacji oraz upewnić się, że CSV zawiera oczekiwane wartości na poszczególnych kolumnach i wierszach.

### Description
- Dodano `StrategyControllerIntegrationTest` w `src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java`, który importuje notowania przez `/v1/quotation/import/csv`, wywołuje `/v1/strategy/dualEquityMomentum` i parsuje odpowiedź CSV do listy map, a następnie sprawdza wartości kolumn.
- Dodano `SimulationControllerIntegrationTest` w `src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java`, który analogicznie importuje notowania, wywołuje `/v1/simulation/dualEquityMomentum`, parsuje CSV i asercyjnie weryfikuje kolumnę `Results` oraz `Transaction`.
- Oba testy zawierają helpery `importQuotations(...)`, `parseCsv(...)` i `assertCsvRow(...)` aby zasilić dane wejściowe, wygodnie sparsować CSV i porównać wartości po nazwach kolumn niezależnie od kolejności nagłówka.

### Testing
- Dodałem testy i skomitowałem pliki, ale uruchomienie `mvn -q -Dtest=StrategyControllerIntegrationTest,SimulationControllerIntegrationTest test` nie powiodło się z powodu niemożności pobrania parent POM Spring Boot (`org.springframework.boot:spring-boot-starter-parent:2.5.5`) z Maven Central (HTTP 403), więc testy nie zostały wykonane w tym środowisku.
- Pliki testowe zostały sprawdzone lokalnie w repozytorium i skomitowane: `src/test/java/piotrholda/portfoliomanager/strategy/http/StrategyControllerIntegrationTest.java` oraz `src/test/java/piotrholda/portfoliomanager/simulation/in/http/SimulationControllerIntegrationTest.java`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd0a26c7c8331b0d56ed725b89231)